### PR TITLE
Add support for compiling on Mac OSX

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,11 @@
       "target_name": "crypt3",
       "sources": [ "./deps/crypt3.cc" ],
       "link_settings": {
-        "libraries": ["-lcrypt"]
+        "conditions": [
+          ['OS!="mac"', {
+            "libraries": ["-lcrypt"]
+          }]
+        ]
       }
     }
   ]

--- a/deps/crypt3.cc
+++ b/deps/crypt3.cc
@@ -5,7 +5,11 @@
 
 #include <time.h>
 #include <stdlib.h>
+#ifdef __APPLE__
+#include <unistd.h>
+#else
 #include <crypt.h>
+#endif
 
 using namespace v8;
 


### PR DESCRIPTION
On Mac OSX -lcrypt is not needed and will cause a linker error. Additionally, crypt() is defined in unistd.h, not crypt.h.
